### PR TITLE
Add `Cargo.lock` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+Cargo.lock


### PR DESCRIPTION
We do not need this and it will have diffs almost every PR. Let's toss it.