### PR TITLE
fix: use arkworks pairings for final pairing check

### DIFF
--- a/barustenberg/src/ecc/mod.rs
+++ b/barustenberg/src/ecc/mod.rs
@@ -7,15 +7,6 @@ pub(crate) mod curves;
 
 pub(crate) struct MillerLines;
 
-pub(crate) fn reduced_ate_pairing_batch_precomputed<G: AffineRepr>(
-    _p_affines: &[G],
-    _miller_lines: &Vec<MillerLines>,
-    _num_points: usize,
-) -> Fq12 {
-    // TODO compilation placeholder come back here bb
-    todo!("see comment")
-}
-
 #[inline]
 pub(crate) fn conditionally_subtract_from_double_modulus<Fr: Field + FftField>(
     _this: &Fr,

--- a/barustenberg/src/plonk/proof_system/prover/test.rs
+++ b/barustenberg/src/plonk/proof_system/prover/test.rs
@@ -260,7 +260,7 @@ fn generate_test_data<'a, H: BarretenHasher + Default + 'static>(
     let reference_string = Rc::new(RefCell::new(FileReferenceString::new(
         n + 1,
         "../srs_db/ignition",
-    )));
+    ).unwrap()));
     let key = Rc::new(RefCell::new(ProvingKey::new(
         n,
         0,

--- a/barustenberg/src/plonk/proof_system/verifier/mod.rs
+++ b/barustenberg/src/plonk/proof_system/verifier/mod.rs
@@ -3,7 +3,6 @@ use crate::{
         curves::bn254_scalar_multiplication::{
             generate_pippenger_point_table, PippengerRuntimeState,
         },
-        reduced_ate_pairing_batch_precomputed, MillerLines,
     },
     plonk::proof_system::constants::NUM_LIMB_BITS_IN_FIELD_SIMULATION,
     transcript::{BarretenHasher, Manifest, Transcript},

--- a/barustenberg/src/plonk/proof_system/verifier/mod.rs
+++ b/barustenberg/src/plonk/proof_system/verifier/mod.rs
@@ -309,7 +309,7 @@ impl<H: BarretenHasher, S: Settings<Hasher = H, Field = Fr, Group = G1Affine>> V
         // The final pairing check of step 12.
         // let result: Fq12 = reduced_ate_pairing_batch_precomputed(&p, &vec![MillerLines], 2);
         // TODO: Optimize by precomputing miller lines for G2
-        let q: [G2Affine; 2] = [G2Affine::identity(), (*self.key).borrow().reference_string.borrow().get_g2x()];
+        let q: [G2Affine; 2] = [G2Affine::generator(), (*self.key).borrow().reference_string.borrow().get_g2x()];
         let result: Fq12 = Bn254::multi_pairing(&p, &q).0;
 
         Ok(result == Fq12::one())

--- a/barustenberg/src/plonk/proof_system/verifier/mod.rs
+++ b/barustenberg/src/plonk/proof_system/verifier/mod.rs
@@ -9,9 +9,10 @@ use crate::{
     transcript::{BarretenHasher, Manifest, Transcript},
 };
 
-use ark_bn254::{Fq, Fq12, Fr, G1Affine, G1Projective};
+use ark_bn254::{Bn254, Fq, Fq12, Fr, G1Affine, G1Projective, G2Affine};
 use ark_ec::AffineRepr;
 use ark_ec::CurveGroup;
+use ark_ec::pairing::Pairing;
 use ark_ff::{BigInteger, Field, One, Zero};
 
 use super::{
@@ -29,7 +30,7 @@ use anyhow::{anyhow, Result};
 #[cfg(test)]
 mod test;
 
-/// Verifier struct 
+/// Verifier struct
 #[derive(Debug)]
 pub struct Verifier<H: BarretenHasher, S: Settings<Hasher = H, Field = Fr, Group = G1Affine>> {
     settings: S,
@@ -40,7 +41,7 @@ pub struct Verifier<H: BarretenHasher, S: Settings<Hasher = H, Field = Fr, Group
     pub(crate) commitment_scheme: Box<KateCommitmentScheme<H, Fq, Fr, G1Affine>>,
 }
 
-/// verifier interface 
+/// verifier interface
 impl<H: BarretenHasher, S: Settings<Hasher = H, Field = Fr, Group = G1Affine>> Verifier<H, S> {
 
     /// Constructor
@@ -307,7 +308,10 @@ impl<H: BarretenHasher, S: Settings<Hasher = H, Field = Fr, Group = G1Affine>> V
         }
 
         // The final pairing check of step 12.
-        let result: Fq12 = reduced_ate_pairing_batch_precomputed(&p, &vec![MillerLines], 2);
+        // let result: Fq12 = reduced_ate_pairing_batch_precomputed(&p, &vec![MillerLines], 2);
+        // TODO: Optimize by precomputing miller lines for G2
+        let q: [G2Affine; 2] = [G2Affine::identity(), (*self.key).borrow().reference_string.borrow().get_g2x()];
+        let result: Fq12 = Bn254::multi_pairing(&p, &q).0;
 
         Ok(result == Fq12::one())
     }


### PR DESCRIPTION
Nuke `reduced_ate_pairing_batch_precomputed` for now and use arkworks pairing

Relevant pre-optimized part in bb
https://github.com/AztecProtocol/barretenberg/blob/ad615ee7dc931d3dbea041e47c96b9d8dccebf98/cpp/src/barretenberg/srs/reference_string/file_reference_string.cpp#L13-L15

Addresses #45, #57